### PR TITLE
Add indieweb-home for homepage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: build
+
+# For node debug, default to only this lib's logs.
+# Use DEBUG=* for all.
+NODE?=iojs --harmony
+DEBUG?=indieweb*
+
+default: build
+
+build: node_modules
+
+clean:
+	rm -rf node_modules
+
+# if package.json changes, install
+node_modules: package.json
+	npm install
+	touch $@
+
+server: build
+	DEBUG=$(DEBUG) $(NODE) index.js
+
+watch: build
+	DEBUG=$(DEBUG) nodemon index.js
+
+test: build config.test.json
+	npm test

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,5 @@ server: build
 watch: build
 	DEBUG=$(DEBUG) $(NODEMON) index.js
 
-test: build config.test.json
+test: build
 	npm test

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: build
 
-# For node debug, default to only this lib's logs.
+# For debug logs, default to only this lib's logs.
 # Use DEBUG=* for all.
-NODE?=iojs --harmony
 DEBUG?=indieweb*
+NODE?=iojs --harmony
+NODEMON?=./node_modules/.bin/nodemon --exec "iojs --harmony"
 
 default: build
 
@@ -21,7 +22,7 @@ server: build
 	DEBUG=$(DEBUG) $(NODE) index.js
 
 watch: build
-	DEBUG=$(DEBUG) nodemon index.js
+	DEBUG=$(DEBUG) $(NODEMON) index.js
 
 test: build config.test.json
 	npm test

--- a/README.md
+++ b/README.md
@@ -14,17 +14,44 @@ Future
 * [MicroPub](http://indiewebcamp.com/Micropub)? Is that a thing?
 * [Social API](https://www.w3.org/wiki/Socialwg/Social_API/Sorting_user_stories)s
 
-## Installation
-
-Add it to your project with `npm install --save indieweb`.
-
 ## Run it
 
-`npm start`
+`make server`
 
-Want debug logs?
+Restart on file changes with `make watch`.
 
-`DEBUG=* npm start`
+### Configuration
+
+Configuration is accomplished with both config files (in [./config](./config)) and environment variables. Environment Variables have a higher priority.
+
+Configuration defaults are loaded from [defaults.json](./config/defaults.json).
+
+Accepted configuration parameters:
+
+* `indieweb` - General settings that are passed to all modules
+  * `.domain` - Public domain of your indieweb
+  * `.me` - A JSON Object describing the owner of this site. Currently this uses a JSON-LD Serialization of an [AS Person](http://www.w3.org/TR/2015/WD-activitystreams-vocabulary-20150129/#dfn-person).
+* `indieweb-home` - Settings for the homepage module
+  * `.title` - Title of the page
+* `DEBUG` - Exactly as described in [debug README](https://www.npmjs.com/package/debug). `DEBUG=*` to show all logs.
+* `config` - Path to config file other than defaults.json. `config=/path/to/config.json make server`
+* `PORT` - Port to listen for HTTP traffic on
+* `findPortBase` - If no `PORT`, [portfinder](https://www.npmjs.com/package/portfinder) will start at this port and look 1 by 1 to find an open port
+
+## Use in another webapp
+
+If you prefer, you can use `indieweb` as a library.
+
+Install with `npm install --save indieweb`.
+
+Use like any other express app.
+* TODO: easily interop with other patterns like koa
+
+```javascript
+const yourApp = require('express')();
+const indiewebConfig = {};
+yourApp.use('/indieweb', require('indieweb')(indiewebConfig))
+```
 
 ## Want a feature?
 

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,4 +1,16 @@
 {
-  "domain": "my-indeweb.example.com",
-  "findPortBase": 8000
+  "findPortBase": 8000,
+  "indieweb": {
+    "domain": "my-indeweb.example.com",
+    "me": {
+      "@context": "http://www.w3.org/ns/activitystreams",
+      "@type": "Person",
+      "displayName": "Jane \"Indiana\" Doe",
+      "image": "https://randomuser.me/api/portraits/med/women/77.jpg"
+    }
+  },
+  "indieweb-home": {
+    "template": "index.html",
+    "title": "Jane's Indieweb"
+  }
 }

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,4 +1,4 @@
 {
   "domain": "my-indeweb.example.com",
-  "PORT": 8000
+  "findPortBase": 8000
 }

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,0 +1,3 @@
+{
+  "domain": "my-indeweb.example.com"
+}

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,3 +1,4 @@
 {
-  "domain": "my-indeweb.example.com"
+  "domain": "my-indeweb.example.com",
+  "PORT": 8000
 }

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -10,7 +10,6 @@
     }
   },
   "indieweb-home": {
-    "template": "index.html",
     "title": "Jane's Indieweb"
   }
 }

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,26 @@
+var log = require('debug')('indieweb/config');
+
+var config = module.exports = require('nconf')
+  .argv({
+    config: {
+      describe: "Path to config file to use for config values"
+    },
+    port: {
+      describe: "Port to listen for HTTP traffic on",
+    },
+    'https_only': {
+      describe: "Whether the web server should redirect all http requests to https"
+    },
+    'https_only_trust_x_forwarded_proto': {
+      describe: "Whether the web server should trust request.headers['x-forwarded-proto'] when determining whether a request was sent over HTTPS"
+    }
+  })
+  .env()
+
+var configFile = config.get('config');
+if (configFile) {
+  config = config.file(configFile)
+}
+
+config
+  .file(__dirname + '/defaults.json')

--- a/index.js
+++ b/index.js
@@ -1,15 +1,21 @@
 var log = require('debug')('indieweb');
-var config = require('./config');
+const xtend = require('xtend');
+const HomePage = require('./lib/indieweb-home');
 
 /**
  * Create an indieweb server
  */
-var createServer = module.exports = function () {
+var createServer = module.exports = function (config) {
   var app = require('express')()
-  var msg = "Is this the indieweb?";
-  app.get('/', function (req, res, next) {
-    res.send(msg)
-  });
+
+  // Homepage
+  app.use('/', new HomePage(xtend(
+    config['indieweb-home'],
+    {
+      indieweb: config.indieweb
+    }
+  )).express())
+
   return app;
 }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var log = require('debug')('indieweb');
+var config = require('./config');
 
 /**
  * Create an indieweb server
@@ -20,7 +21,11 @@ if (require.main === module) {
  * Create an indieweb server and listen on env.PORT
  */
 function main() {
-  var port = process.env.PORT || 3000
-  log('listening on port '+port)
-  createServer().listen(port);
+  const getPort = require('./lib/get-port');
+  var configPort = config.get('PORT');
+  Promise.resolve(configPort || getPort())
+  .then(function (port) {
+    log('listening on port '+port)
+    createServer().listen(port);    
+  })
 }

--- a/index.js
+++ b/index.js
@@ -14,18 +14,20 @@ var createServer = module.exports = function () {
 }
 
 if (require.main === module) {
-    main();
+  main();
 }
 
 /**
- * Create an indieweb server and listen on env.PORT
+ * Create an indieweb server and listen on config.PORT
+ * If a port is not configured, find one
  */
 function main() {
+  const config = require('./config').get();
   const getPort = require('./lib/get-port');
-  var configPort = config.get('PORT');
-  Promise.resolve(configPort || getPort())
+  console.log('looking for port from', config.findPortBase)
+  Promise.resolve(config.PORT || getPort(config.findPortBase))
   .then(function (port) {
-    log('listening on port '+port)
-    createServer().listen(port);    
+    log('listening for HTTP on port '+port)
+    createServer(config.get()).listen(port);    
   })
 }

--- a/index.js
+++ b/index.js
@@ -24,10 +24,13 @@ if (require.main === module) {
 function main() {
   const config = require('./config').get();
   const getPort = require('./lib/get-port');
-  console.log('looking for port from', config.findPortBase)
   Promise.resolve(config.PORT || getPort(config.findPortBase))
   .then(function (port) {
     log('listening for HTTP on port '+port)
-    createServer(config.get()).listen(port);    
+    createServer(config).listen(port);    
+  })
+  .then(null, function (err) {
+    console.error(err);
+    process.exit(1);
   })
 }

--- a/lib/get-port.js
+++ b/lib/get-port.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const portfinder = require('portfinder');
+
+/**
+ * Get an available port that an app could listen on.
+ * Starts looking at the provided basePort.
+ * Promise<Number>
+ */
+module.exports = function getPort(basePort) {
+  return new Promise(function (resolve, reject) {
+    createPortfinder(basePort).getPort(function (err, port) {
+      if (err) return reject(err);
+      resolve(port);
+    })
+  })
+}
+
+/**
+ * Create a portfinder that starts at the provided basePort.
+ */
+function createPortfinder(basePort) {
+  const finder = Object.create(portfinder);
+  finder.basePort = basePort;
+  return finder;
+}

--- a/lib/get-port.js
+++ b/lib/get-port.js
@@ -9,18 +9,10 @@ const portfinder = require('portfinder');
  */
 module.exports = function getPort(basePort) {
   return new Promise(function (resolve, reject) {
-    createPortfinder(basePort).getPort(function (err, port) {
+    portfinder.basePort = basePort;
+    portfinder.getPort(function (err, port) {
       if (err) return reject(err);
       resolve(port);
     })
   })
-}
-
-/**
- * Create a portfinder that starts at the provided basePort.
- */
-function createPortfinder(basePort) {
-  const finder = Object.create(portfinder);
-  finder.basePort = basePort;
-  return finder;
 }

--- a/lib/indieweb-home.js
+++ b/lib/indieweb-home.js
@@ -1,0 +1,54 @@
+'use strict';
+const tidyHtml = require('./tidy-html');
+
+// Private method to render HTML for the homepage
+var renderHtml = Symbol('IndieWebHome#renderHtml');
+
+/** 
+ * A 'Home' Server
+ * Currently it just renders some boilerplate HTML.
+ */
+module.exports = class IndieWebHome {
+  constructor(config) {
+    this[renderHtml] = renderHomePageHtml.bind(this, config);
+  }
+  express() {
+    var self = this;
+    return function (req, res, next) {
+      self[renderHtml]()
+      .then(function (html) {
+        res.send(html);
+      })
+    }    
+  }
+}
+
+function renderHomePageHtml(config) {
+  const domain = config.indieweb.domain;
+  const me = config.indieweb.me;
+  const html = `
+    <!doctype html>
+    <head>
+      <link rel="pingback" href="https://webmention.io/${ domain }/xmlrpc" />
+      <link rel="webmention" href="https://webmention.io/${ domain }/webmention" />
+      <title>${ config.title }</title>
+    </head>
+    <h1>${ config.title }</h1>
+      <p>
+        Welcome to my <a href="http://indiewebcamp.com/indieweb">indieweb</a>,
+        hosted at <a href="${ domain }">${ domain }</a>.
+      </p>
+      ${
+        me.image
+        ? `<img src="${ me.image }" />`
+        : undefined
+      }
+      <h2>'me'</h2>
+        <pre>${ JSON.stringify(me, null, 2) }</pre>
+      <h2>Posts</h2>
+        <p>#TODO</h2>
+    <footer>©${ new Date().getFullYear() }</footer>
+  `;
+  return tidyHtml(html);
+}
+

--- a/lib/tidy-html.js
+++ b/lib/tidy-html.js
@@ -1,0 +1,16 @@
+const tidyAsync = require('htmltidy2').tidy
+
+module.exports = function (text, options) {
+  options = options || {
+    indent: true,
+    'indent-attributes': true,
+    'sort-attributes': 'alpha',
+    'vertical-space': true
+  };
+  return new Promise(function (resolve, reject) {
+    tidyAsync(text, options, function (err, tidiedHtml) {
+      if (err) return reject(err)
+      return resolve(tidiedHtml)
+    })
+  })
+}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "version": "0.0.1-dev.0",
   "description": "",
   "main": "index.js",
+  "engines": {
+    "iojs": "1.4.x",
+    "harmony": true
+  },
   "scripts": {
-    "start": "node index.js",
+    "start": "iojs --harmony index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
   "dependencies": {
     "debug": "^2.1.3",
     "express": "^4.12.3",
+    "htmltidy2": "^0.1.4",
     "nconf": "^0.7.1",
-    "portfinder": "^0.4.0"
+    "portfinder": "^0.4.0",
+    "xtend": "^4.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^1.3.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "debug": "^2.1.3",
-    "express": "^4.12.3"
+    "express": "^4.12.3",
+    "nconf": "^0.7.1",
+    "portfinder": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indieweb",
-  "version": "0.0.1-dev.0",
+  "version": "0.0.1-dev.1",
   "description": "",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Try it out [on Heroku](indieweb-example.herokuapp.com).

Features
- Configuration files are now supported to configure `indieweb` and submodules, and these live in [./config](./config).
  - You can provide your own config file with the `config` env var, e.g. `config=/path/to/config.json make server`
  - Default values are provided by [./config/defaults.json](./config/defaults.json) for a fictitious Jane Doe
- Introduce an `indieweb-home` module that is mounted at the root of the `indieweb` server.
  - Displays your domain (`config.indieweb.domain`)
  - Renders an `<h1>` title and head `<title>` with the value from `config.indieweb-home.title`
  - Renders some information about 'me' (e.g. `.image`) from `config.indieweb.me`
  - Includes `<link />`s to register `webmention.io` as a webmention receiver
  - Tidy's output HTML with [htmltidy2](https://www.npmjs.com/package/htmltidy2)
- If you do not provide a specific `config.PORT` when running `indieweb`, then it will attempt to find an open port (usually starting with 8000), and automatically start there.

Codebase
- Added a `Makefile` in the project root. Targets:
  - `default` - same as `build`
  - `server` - run `index.js` to run the indieweb server with default configs.
    - You can use env vars to configure most things, e.g. `DEBUG=* PORT=8001 make server` will run on port 8001 and with all debug logs enabled.
  - `watch` - like server, but restarts when files change (thanks to [nodemon](https://www.npmjs.com/package/nodemon))
  - `build` - install all the npm dependencies
  - `clean` - remove `./node_modules` to start over

TODO
- Allow users to configure their own templates for things like the homepage
- Support displaying posts, articles, notes, etc.
