### PR TITLE
Https

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Accepted configuration parameters:
 * `config` - Path to config file other than defaults.json. `config=/path/to/config.json make server`
 * `PORT` - Port to listen for HTTP traffic on
 * `findPortBase` - If no `PORT`, [portfinder](https://www.npmjs.com/package/portfinder) will start at this port and look 1 by 1 to find an open port
+* `https` - Settings for HTTPS support
+  * `.require` - Require HTTPS. All requests over http will be redirected to https.
+  * `.trustXForwardedProto` - If incoming protocol is 'http', but the request has header for 'X-Forwarded-Proto: https', still treat it as if https. [Relevant StackOverflow](https://stackoverflow.com/questions/7185074/heroku-nodejs-http-to-https-ssl-forced-redirect)
 
 ## Use in another webapp
 

--- a/config/index.js
+++ b/config/index.js
@@ -5,17 +5,14 @@ var config = module.exports = require('nconf')
     config: {
       describe: "Path to config file to use for config values"
     },
-    port: {
+    PORT: {
       describe: "Port to listen for HTTP traffic on",
-    },
-    'https_only': {
-      describe: "Whether the web server should redirect all http requests to https"
-    },
-    'https_only_trust_x_forwarded_proto': {
-      describe: "Whether the web server should trust request.headers['x-forwarded-proto'] when determining whether a request was sent over HTTPS"
     }
+    // TODO: https.*
   })
-  .env()
+  .env({
+    separator: '_'
+  })
 
 var configFile = config.get('config');
 if (configFile) {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,12 @@ const HomePage = require('./lib/indieweb-home');
 var createServer = module.exports = function (config) {
   var app = require('express')()
 
+  // Require HTTPS?
+  if (config.https && config.https.require) {
+    log('Configuring to require HTTPS')
+    app.use(require('express-sslify').HTTPS(config.https.trustXForwardedProto))    
+  }
+
   // Homepage
   app.use('/', new HomePage(xtend(
     config['indieweb-home'],

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "debug": "^2.1.3",
     "express": "^4.12.3",
+    "express-sslify": "^0.1.1",
     "htmltidy2": "^0.1.4",
     "nconf": "^0.7.1",
     "portfinder": "^0.4.0",


### PR DESCRIPTION
Add support for ensuring all incoming traffic uses HTTPS, and describe configs in the README.

For context, after deploying this change to [indieweb-example.herokuapp.com](https://indieweb-example.herokuapp.com), I changed the env variables to enable this with:

```
heroku config:set https_require=true https_trustXForwardedProto=true
```

Voila, now it will redirect http traffic to https. e.g. [http://indieweb-example.herokuapp.com](http://indieweb-example.herokuapp.com)
