### PR TITLE
HTTPS listen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+## What DEBUG logs to show
+## default is only logs from this package
+# DEBUG=indieweb*
+
+## Whether web server should redirect http -> https
+# https_require=1
+
+## Whether to listen for https on a port
+# https_listen=1
+# https_port=8001
+
+## HTTPS key/cert paths
+# https_key=/path/to/the.key
+# https_cert=/path/to/the.cert

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+/.env

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@
 
 # For debug logs, default to only this lib's logs.
 # Use DEBUG=* for all.
-DEBUG?=indieweb*
 NODE?=iojs --harmony
 NODEMON?=./node_modules/.bin/nodemon --exec "iojs --harmony"
+# Source env vars from .env
+ENV_FILE?=.env
+ENV=env $$(cat $(ENV_FILE) | xargs)
 
 default: build
 
@@ -19,10 +21,10 @@ node_modules: package.json
 	touch $@
 
 server: build
-	DEBUG=$(DEBUG) $(NODE) index.js
+	$(ENV) $(NODE) index.js
 
 watch: build
-	DEBUG=$(DEBUG) $(NODEMON) index.js
+	$(ENV) $(NODEMON) index.js
 
 test: build
 	npm test


### PR DESCRIPTION
- Allow for configuring the process to listen on a port for HTTPS traffic. Previously this would only listen for HTTP traffic
